### PR TITLE
[Feature #162472444] create an intervention endpoint

### DIFF
--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -101,6 +101,15 @@ class RedFlagTestCase(unittest.TestCase):
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
+    def test_post_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data)
+        )
+        result = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('Created intervention record', str(result))
+
+
 
 
 

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -60,3 +60,12 @@ class Interventions(Resource):
             "status": 200,
             "data": interventions
         }), 200)
+    
+    def post(self):
+        PARSER.parse_args()
+        data = request.get_json(silent=True)
+        posted = (data['id'], data['type'], data['location'],
+                  data['Images'], data['Videos'], data['comment'])
+        db.create_intervention_record(posted)
+        return{"status": 201, "data": [{"id": data['id'],
+                                        "message":"Created intervention record"}]}, 201


### PR DESCRIPTION
#### What does this PR do?
creates new intervention records

#### Description of Task to be completed?
POST /api/v2/interventions

#### How should this be manually tested?
using postman navigate to the above endpoint and hit send it returns all interventions

#### What are the relevant pivotal tracker stories?
 #162472444

#### Screenshots (if appropriate)
![postnew](https://user-images.githubusercontent.com/17140636/49897625-c41b2500-fe67-11e8-86a8-cc5315882f8f.JPG)
