### PR TITLE
Ft admin can change status 162472481

### DIFF
--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -122,6 +122,15 @@ class RedFlagTestCase(unittest.TestCase):
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 404)
         self.assertIn("intervention record does not exist.", str(result))
+    
+    def test_delete_one_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data5)
+        )
+        response2 = self.client.delete(URL_REDFLAGS_IDD)
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn('Intervention record has been deleted', str(result))
 
 
 

--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -101,6 +101,15 @@ class RedFlagTestCase(unittest.TestCase):
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
+    def test_post_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data)
+        )
+        result = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('Created intervention record', str(result))
+
+
 
 
 

--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -149,6 +149,32 @@ class RedFlagTestCase(unittest.TestCase):
         self.assertEqual(response2.status_code, 200)
         self.assertIn("Updated intervention's comment", str(result))
     
+    def test_update_redflag_status(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data6)
+        )
+        response2 = self.client.patch(
+            URL_REDSTATUS, headers=HEADERS, data=json.dumps(
+                self.redflagpatch
+            )
+        )
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn("Updated redflag record status", str(result))
+
+    def test_update_intervention_status(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data7)
+        )
+        response2 = self.client.patch(
+            URL_INTESTATUS, headers=HEADERS, data=json.dumps(
+                self.interventionpatch
+            )
+        )
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn("Updated intervention record status", str(result))
+    
     def test_delete_one_redflag(self):
         response = self.client.post(
             URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data5)

--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -108,6 +108,20 @@ class RedFlagTestCase(unittest.TestCase):
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 201)
         self.assertIn('Created intervention record', str(result))
+    
+    def test_get_one_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data2)
+        )
+        response2 = self.client.get(URL_REDFLAGS_ID)
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+
+    def test_redflag_not_found(self):
+        response = self.client.get(URL_REDFLAGS_IDS)
+        result = json.loads(response.data)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("intervention record does not exist.", str(result))
 
 
 

--- a/app/api/tests/v2/test_intervention.py
+++ b/app/api/tests/v2/test_intervention.py
@@ -123,6 +123,32 @@ class RedFlagTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn("intervention record does not exist.", str(result))
     
+    def test_update_location_of_one_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data3)
+        )
+        response2 = self.client.patch(
+            URL_LOCATION, headers=HEADERS, data=json.dumps({
+                "location": "Kisumu"
+            })
+        )
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn("Updated intervention's location", str(result))
+
+    def test_update_comment_of_one_redflag(self):
+        response = self.client.post(
+            URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data4)
+        )
+        response2 = self.client.patch(
+            URL_COMMENT, headers=HEADERS, data=json.dumps({
+                "comment": "curruption"
+            })
+        )
+        result = json.loads(response2.data)
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn("Updated intervention's comment", str(result))
+    
     def test_delete_one_redflag(self):
         response = self.client.post(
             URL_REDFLAGS, headers=HEADERS, data=json.dumps(self.data5)

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,11 +1,15 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
-from .views import Interventions, Intervention, Updatelocation, Updatecomment
+from .views import Interventions, AdminUpdatesInterventiontatus, Intervention, AdminupdateRedflagstatus, Updatelocation, Updatecomment
 
 version_two = Blueprint('api_v2', __name__, url_prefix='/api/v2')
 api = Api(version_two)
 api.add_resource(Updatelocation,
                  '/interventions/<int:intervention_id>/location')
 api.add_resource(Updatecomment, '/interventions/<int:intervention_id>/comment')
+api.add_resource(AdminUpdatesInterventiontatus,
+                 '/interventions/<int:intervention_id>/status')
+api.add_resource(AdminupdateRedflagstatus,
+                 '/interventions/<int:intervention_id>/status-red')
 api.add_resource(Interventions, '/interventions')
 api.add_resource(Intervention, '/intervention/<int:intervention_id>')

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,8 +1,11 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
-from .views import Interventions, Intervention
+from .views import Interventions, Intervention, Updatelocation, Updatecomment
 
 version_two = Blueprint('api_v2', __name__, url_prefix='/api/v2')
 api = Api(version_two)
+api.add_resource(Updatelocation,
+                 '/interventions/<int:intervention_id>/location')
+api.add_resource(Updatecomment, '/interventions/<int:intervention_id>/comment')
 api.add_resource(Interventions, '/interventions')
 api.add_resource(Intervention, '/intervention/<int:intervention_id>')

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,7 +1,8 @@
 from flask_restful import Api, Resource
 from flask import Blueprint
-from .views import Interventions
+from .views import Interventions, Intervention
 
 version_two = Blueprint('api_v2', __name__, url_prefix='/api/v2')
 api = Api(version_two)
 api.add_resource(Interventions, '/interventions')
+api.add_resource(Intervention, '/intervention/<int:intervention_id>')

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -98,3 +98,52 @@ class Intervention(Resource):
                     "message": "intervention record does not exist."
                 }]}, 404
 
+
+class Updatecomment(Resource):
+    def patch(self, intervention_id):
+        paserrr = reqparse.RequestParser(bundle_errors=True)
+        paserrr.add_argument('comment',
+                             type=valid_characters,
+                             required=True,
+                             help="comment field cannt be left blank or"
+                             "{error_msg},400"
+                             )
+        paserrr.parse_args()
+        data = request.get_json(silent=True)
+        comment = data["comment"]
+        patched = (comment, intervention_id)
+        intervention = db.findOne(intervention_id)
+        if intervention:
+            db.update_intervention_comment(patched)
+            return{"status": 200, "data":
+                   [{"id": intervention_id, "message":
+                     "Updated intervention's comment"}]}, 200
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404
+
+
+class Updatelocation(Resource):
+    def patch(self, intervention_id):
+        paserr = reqparse.RequestParser(bundle_errors=True)
+        paserr.add_argument('location',
+                            type=valid_characters,
+                            required=True,
+                            help="location field cannt be left blank or"
+                            "{error_msg},400"
+                            )
+        paserr.parse_args()
+        data = request.get_json(silent=True)
+        location = data["location"]
+        patched = (location, intervention_id)
+        intervention = db.findOne(intervention_id)
+        if intervention:
+            db.update_intervention_location(patched)
+            return{"status": 200, "data":
+                   [{"id": intervention_id, "message":
+                     "Updated intervention's location"}]}, 200
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -60,3 +60,12 @@ class Interventions(Resource):
             "status": 200,
             "data": interventions
         }), 200)
+    
+    def post(self):
+        PARSER.parse_args()
+        data = request.get_json(silent=True)
+        posted = (data['id'], data['type'], data['location'],
+                  data['Images'], data['Videos'], data['comment'])
+        db.create_intervention_record(posted)
+        return{"status": 201, "data": [{"id": data['id'],
+                                        "message":"Created intervention record"}]}, 201

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -147,3 +147,85 @@ class Updatelocation(Resource):
                 "data": [{
                     "message": "intervention record does not exist."
                 }]}, 404
+
+
+class AdminUpdatesInterventiontatus(Resource):
+    def patch(self, intervention_id):
+        paserr = reqparse.RequestParser(bundle_errors=True)
+        paserr.add_argument('type',
+                            type=str,
+                            required=True,
+                            choices=("Intervention"),
+                            help="type field cannot be left "
+                            "blank or Bad choice: {error_msg},400"
+                            )
+        paserr.add_argument('isAdmin',
+                            type=str,
+                            required=True,
+                            choices=("True", "False"),
+                            help="Only Admin users allowed"
+                            " or Bad choice: {error_msg},400"
+                            )
+        paserr.add_argument('status',
+                            type=str,
+                            required=True,
+                            choices=("under investigation",
+                                     "rejected", "resolved"),
+                            help="status field cannot be left "
+                            "blank or Bad choice: {error_msg},400"
+                            )
+        paserr.parse_args()
+        data = request.get_json(silent=True)
+        status = data["status"]
+        patched = (status, intervention_id)
+        intervention = db.findOne(intervention_id)
+        if intervention:
+            db.update_intervention_status(patched)
+            return{"status": 200, "data":
+                   [{"id": intervention_id, "message":
+                     "Updated intervention record status"}]}, 200
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404
+
+
+class AdminupdateRedflagstatus(Resource):
+    def patch(self, intervention_id):
+        paserr = reqparse.RequestParser(bundle_errors=True)
+        paserr.add_argument('type',
+                            type=str,
+                            required=True,
+                            choices=("Redflag"),
+                            help="type field cannot be left "
+                            "blank or Bad choice: {error_msg},400"
+                            )
+        paserr.add_argument('isAdmin',
+                            type=str,
+                            required=True,
+                            choices=("True", "False"),
+                            help="Only Admin users allowed "
+                            "or Bad choice: {error_msg},400"
+                            )
+        paserr.add_argument('status',
+                            type=str,
+                            required=True,
+                            choices=("under investigation",
+                                     "rejected", "resolved"),
+                            help="status field cannot be left "
+                            "blank or Bad choice: {error_msg},400"
+                            )
+        paserr.parse_args()
+        data = request.get_json(silent=True)
+        status = data["status"]
+        patched = (status, intervention_id)
+        intervention = db.findOne(intervention_id)
+        if intervention:
+            db.update_redflag_status(patched)
+            return{"status": 200, "data":
+                   [{"id": intervention_id, "message":
+                     "Updated redflag record status"}]}, 200
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -83,3 +83,18 @@ class Intervention(Resource):
                 "data": [{
                     "message": "intervention record does not exist."
                 }]}, 404
+    
+    def delete(self, intervention_id):
+        intervention = db.findOne(intervention_id)
+        if intervention:
+            db.delete_specific_record(intervention_id)
+            return make_response(jsonify({
+                "status": 200,
+                "data": [{"id": intervention_id,
+                          "message": "Intervention record has been deleted"}]
+            }), 200)
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404
+

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -69,3 +69,17 @@ class Interventions(Resource):
         db.create_intervention_record(posted)
         return{"status": 201, "data": [{"id": data['id'],
                                         "message":"Created intervention record"}]}, 201
+
+
+class Intervention(Resource):
+    def get(self, intervention_id):
+        intervention = db.get_specific_intervention_record(intervention_id)
+        if intervention:
+            return make_response(jsonify({
+                "status": 200,
+                "data": intervention
+            }), 200)
+        return {"status": 404,
+                "data": [{
+                    "message": "intervention record does not exist."
+                }]}, 404


### PR DESCRIPTION
#### What does this PR do?
Add API  endpoint where an admin can change the status of the red flag and interventions 
#### Description of Task to be completed?
PATCH /api/v2/interventions/5/status
PATCH  /api/v2/interventions/5/status-red
#### How should this be manually tested?
using postman an admin user navigates  to one of the above endpoints and update the status of the red flag and interventions
#### What are the relevant pivotal tracker stories?
#162472481
#### Screenshots (if appropriate)
![admin ptach](https://user-images.githubusercontent.com/17140636/49902024-ddc26980-fe73-11e8-9031-8f4134c80c0f.JPG)
